### PR TITLE
feat: Add support for caching of certificates

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,9 @@
         "google/cloud-scheduler": "^1.6",
         "phpseclib/phpseclib": "^3.0",
         "google/auth": "^v1.29.1",
-        "laravel/framework": "^10.0|^11.0"
+        "laravel/framework": "^10.0|^11.0",
+        "php": "^8.1",
+        "symfony/cache": "^6.4"
     },
     "require-dev": {
         "mockery/mockery": "^1.5",

--- a/src/OpenIdVerificatorConcrete.php
+++ b/src/OpenIdVerificatorConcrete.php
@@ -7,13 +7,20 @@ use Illuminate\Support\Facades\Facade;
 
 class OpenIdVerificatorConcrete extends Facade
 {
+    private AccessToken $accessToken;
+
+    public function __construct(AccessToken $accessToken)
+    {
+        $this->accessToken = $accessToken;
+    }
+
     public function verify(?string $token, array $config): void
     {
         if (! $token) {
             throw new CloudSchedulerException('Missing [Authorization] header');
         }
 
-        $payload = (new AccessToken())->verify(
+        $payload = $this->accessToken->verify(
             $token,
             [
                 'audience' => config('cloud-scheduler.app_url'),


### PR DESCRIPTION
The `AccessToken` class supports being provided aCache to cache the certificates. This means they don't need to be retrieved on every call of the endpoint, as they rarely change.

This adds `symfony/cache` as it provides a PSR16Adapter that Laravel uses when trying to resolve the CacheItemPoolInterface.